### PR TITLE
added instance name to intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,24 +138,25 @@ python model_unit_test.py
 Here is sample output from one run:
 
 ```shell
- Ask a question or type 'exit': Have 0x111111 mint 10 USDC to 0x222222 and then have 0x222222 send 5 USDC to 0x333333.
+  Ask a question or type 'exit': Have 0x111111 mint 10 USDC to 0x222222 and then have 0x222222 send 5 USDC to 0x333333.
 
-LOG: Approving workflow 89d641b2-f7fb-48d3-bd28-d1fd07b74faa with intents: [{"function":"mint_usdc","arguments":{"minter":"0x111111","receiver":"0x222222","amount":10}}, {"function":"send_usdc","arguments":{"sender":"0x222222","receiver":"0x333333","amount":5}}].
+LOG: Approving workflow with intents: ['{"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}', '{"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"}']
+LOG: Approved workflow f0082344-018c-4d5c-856a-fb8989ab6bf2 with intents: [{"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}, {"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"}].
+Override this method with your own approval logic.
 
-LOG: Starting action {"function":"mint_usdc","arguments":{"minter":"0x111111","receiver":"0x222222","amount":10}}
+LOG: Starting action {"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}
 Minting 10 USDC by 0x111111 to 0x222222
-LOG: Finished action {"function":"mint_usdc","arguments":{"minter":"0x111111","receiver":"0x222222","amount":10}} with result txhash=0987654321
+LOG: Finished action {"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"} with result txhash=0987654321
 
-LOG: Starting action {"function":"send_usdc","arguments":{"sender":"0x222222","receiver":"0x333333","amount":5}}
+LOG: Starting action {"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"}
 Sending 5 USDC from 0x222222 to 0x333333
-LOG: Finished action {"function":"send_usdc","arguments":{"sender":"0x222222","receiver":"0x333333","amount":5}} with result txhash=1234567890
+LOG: Finished action {"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"} with result txhash=1234567890
 
 LOG: Workflow completed successfully with result txhash=1234567890
 The transactions were successfully executed. Here are the transaction hashes:
 
-1. Mint 10 USDC from `0x111111` to `0x222222`: `0987654321`
-2. Send 5 USDC from `0x222222` to `0x333333`: `1234567890`
-
+1. Mint 10 USDC from `0x111111` to `0x222222`: `txhash=0987654321`
+2. Send 5 USDC from `0x222222` to `0x333333`: `txhash=1234567890`
 
 ```
 

--- a/src/agent_tool.py
+++ b/src/agent_tool.py
@@ -4,7 +4,7 @@
 # terms governing use, modification, and redistribution, is contained in the
 # file LICENSE.MIT at the root of the source code distribution tree.
 #
-# Portions Copyright (c) 2025, Circle Internet Financial, LTD.  All rights reserved
+# Portions Copyright (c) 2025, Circle Internet Group, Inc.  All rights reserved
 # Circle contributions are licensed under the Apache 2.0 License.
 #
 # SPDX-License-Identifier: Apache-2.0 AND MIT

--- a/src/workflow_manager.py
+++ b/src/workflow_manager.py
@@ -54,7 +54,12 @@ class Action:
             if current.get('function_name') != incoming.get('function_name') and current.get('function') != incoming.get('function'):
                 if self.intent != intent:
                     return ManagerResponse(False, f"Function name mismatch: {current.get('function_name', current.get('function'))} vs {incoming.get('function_name', incoming.get('function'))}")
-            
+
+            # Compare instance
+            if current.get('instance') != incoming.get('instance'):
+                if self.intent != intent:
+                    return ManagerResponse(False, f"Instance mismatch: {current.get('instance')} vs {incoming.get('instance')}")
+
             # Compare arguments
             current_args = {k: v for k, v in current.get('args', current.get('arguments', {})).items()}
             incoming_args = {k: v for k, v in incoming.get('args', incoming.get('arguments', {})).items()}
@@ -174,7 +179,7 @@ class WorkflowManager(SecureContext):
 
     # override this method to get approval from UI
     def get_approval(self, workflow: Workflow) -> ManagerResponse:
-        self.log(f"Approving workflow {workflow.wfid} with intents: {workflow.actions}.\nOverride this method with your own approval logic.")
+        self.log(f"Approved workflow {workflow.wfid} with intents: {workflow.actions}.\nOverride this method with your own approval logic.")
         return ManagerResponse(True, 'Approved')
 
     # AI agents can call this function to get approval for a workflow


### PR DESCRIPTION
Intents should include the instance id associated with the tool (it matters if the tool will send funds from wallet A or wallet B. Since by default all InstanceAgents will bind themselves to their method tools, `secure_tool.py` checks for the field `name` that is common to all agents. Otherwise it checks for the string representation of the instance. Default behavior is to use the classname and default ID assigned by Python. 

- fixed copyright on `angel_tool.py`
- secure_tool includes instance name (or default id assigned by Python) in intent
- WorkflowManager checks instance matches in intent