### PR TITLE
chore(TECHOPS-18898): use conventional commits and attach github release assets

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,36 +1,33 @@
-name: Test Release
+name: Test
 
 on:
-  pull_request:
-    branches:
-      - master
   workflow_call:
 
 jobs:
-    test:
-        runs-on: large-spot
-        steps: 
-            - uses: actions/checkout@v4
+  test:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v4
 
-            - name: Set up Python 3.10
-              uses: actions/setup-python@v5
-              with:
-                  python-version: '3.10'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
-            - name: Install dependencies
-              run: |
-                python -m pip install --upgrade pip
-                python -m pip install -r requirements.txt
-                python -m pip install pytest-asyncio
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
 
-            - name: Set up build tools
-              run: |
-                python -m pip install build
+      - name: Set up build tools
+        run: |
+          python -m pip install build
 
-            - name: Install circle-ooak
-              run: |
-                python -m build
-                python -m pip install -e .
+      - name: Install circle-ooak
+        run: |
+          python -m build
+          python -m pip install -e .
 
-            - name: Run tests
-              run: python -m pytest test/model_unit_test.py
+      - name: Run tests
+        run: python -m pytest test/ -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,75 @@
-name: Release
+name: Main Pipeline
 
 on:
+  pull_request:
+    branches: [master]
   push:
-    branches:
-      - master
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/release-test.yml
 
-    test:
-      uses: ./.github/workflows/release-test.yml
+  release-please:
+    if: github.event_name == 'push'
+    uses: circlefin/circle-public-github-workflows/.github/workflows/conventional-commit-release.yaml@v1
+    with:
+      release_type: python
+      additional_unqualified_tags: true
+      extra_tags: stable
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    release:
-      name: Release
-      runs-on: large-spot
-      needs: test
-      steps:
-        - uses: actions/checkout@v4
+  pypi-publish:
+    name: Publish to PyPI
+    if: needs.release-please.outputs.release_created == 'true'
+    needs: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          
+      - name: Build package
+        run: python -m build
         
-        - name: Set up Python
-          uses: actions/setup-python@v5
-          with:
-            python-version: '3.10'
-            
-        - name: Install build dependencies
-          run: |
-            python -m pip install --upgrade pip
-            python -m pip install build twine
-            
-        - name: Build package
-          run: python -m build
-          
-        - name: Check distribution
-          run: twine check dist/*
-          
-        - name: Publish to PyPI
-          env:
-            TWINE_USERNAME: __token__
-            TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          run: twine upload dist/*       
+      - name: Check distribution
+        run: twine check dist/*
+        
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
+
+      - name: Upload build artifacts for release
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  github-release:
+    name: Create GitHub Release with Assets
+    if: needs.release-please.outputs.release_created == 'true'
+    needs: [release-please, pypi-publish]
+    uses: circlefin/circle-public-github-workflows/.github/workflows/attach-release-assets.yaml@v1
+    with:
+      release_tag: ${{ needs.release-please.outputs.release_tag }}
+      artifact_file_globs: |
+        *.whl
+        *.tar.gz
+      create_manifest: true
+      generate_sbom: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv
+openai
 openai-agents==0.2.6


### PR DESCRIPTION
## Overview
The changes in this PR use Circle best practices for opensource. 

* updated the release pipeline to use conventional commits
* use release please to manage releases
* use github releases, so that repo tags and release assests are configured properly for this repo

## Important Changes for Contributors ⚠️ 
* contributors should use conventional commit standards for all changes and PR titles moving forward; https://www.conventionalcommits.org/en/v1.0.0/
* release please pipeline will create a seperate PR that much be merged to create a new releas, automatially bump version and publish to pypi: https://github.com/googleapis/release-please
