### PR TITLE
chore(TECHOPS-19100): fix ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
+  issues: write
 
 jobs:
   test:
@@ -24,6 +26,9 @@ jobs:
       extra_tags: stable
     secrets:
       RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
 
   pypi-publish:
     name: Publish to PyPI


### PR DESCRIPTION
Saw the following error in the master build when creating the release please PR: 
```
Error: release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

updating build permissions to allow Github Actions to make changes needed for releases. 