### PR TITLE
chore(TECHOPS-18898): fix gpg error in release workflow

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -21,8 +21,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip
                 python -m pip install -r requirements.txt
-                python -m pip install -r requirements-test.txt
-
+                python -m pip install pytest
             # - name: Lint with flake8
             #   run: |
             #     # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -22,12 +22,6 @@ jobs:
                 python -m pip install --upgrade pip
                 python -m pip install -r requirements.txt
                 python -m pip install pytest
-            # - name: Lint with flake8
-            #   run: |
-            #     # stop the build if there are Python syntax errors or undefined names
-            #     # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-            #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-            #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics\
 
             - name: Run tests
               run: python -m pytest test/model_unit_test.py

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,34 @@
+name: Test Release
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+    test:
+        runs-on: large-spot
+        steps: 
+            - uses: actions/checkout@v4
+
+            - name: Set up Python 3.9
+              uses: actions/setup-python@v5
+              with:
+                  python-version: 3.9
+
+            - name: Install dependencies
+              run: |
+                python -m pip install --upgrade pip
+                python -m pip install -r requirements.txt
+                python -m pip install -r requirements-test.txt
+
+            # - name: Lint with flake8
+            #   run: |
+            #     # stop the build if there are Python syntax errors or undefined names
+            #     # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+            #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+            #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics\
+
+            - name: Run tests
+              run: python -m pytest test/model_unit_test.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+    test:
+      uses: ./.github/workflows/release-test.yml
+
+    release:
+      name: Release
+      runs-on: large-spot
+      needs: test
+      steps:
+        - uses: actions/checkout@v4
+        
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.9'
+            
+        - name: Install build dependencies
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install build twine
+            
+        - name: Build package
+          run: python -m build
+          
+        - name: Check distribution
+          run: twine check dist/*
+          
+        - name: Publish to PyPI
+          env:
+            TWINE_USERNAME: __token__
+            TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          run: twine upload dist/*       

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
-pytest
-pytest-asyncio 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio 


### PR DESCRIPTION
## Summary
This PR adds the required GPG key fingerprint secret to fix the ERR 67108891 Not found <GPG Agent> error that occurs during the release process on Ubuntu 24.04 runners.

## Details
* The crazy-max/ghaction-import-gpg@v6.1.0 action requires a fingerprint when working with GPG subkeys, especially on newer Ubuntu versions
* Added PUBLIC_RELEASES_GPG_FINGERPRINT to the secrets passed to the workflow
This ensures the action can properly identify the signing key and communicate with the GPG agent