### PR TITLE
docs: add community example — trustless USDC agents (OOAK + zkML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ approves the list of intents and returns a WorkflowId.
 3. Execute. The agent now calls the @secure_tools in the correct order with the WorkflowId. The
 WorkflowManager ensures that each subsequent function call matches the approved workflow.
 
-Sample code can be found at `https://github.com/circlefin/circle-ooak/example`
+Sample code can be found at `https://github.com/circlefin/circle-ooak/tree/main/example`
 
-Below is an exmple of a `WalletWorkflowAgent`.
+Below is an example of a `WalletWorkflowAgent`.
 
 ```python
 from circle_ooak.instance_agent import InstanceAgent
@@ -149,6 +149,10 @@ python example/run_agent.py instance
 # To run unit tests
 python -m pytest test/model_unit_test.py -v
 ```
+
+## Community Examples
+- Trustless USDC Agents (OOAK + zkML) — community example by @hshadab demonstrating a zkML-gated `@secure_tool` flow that proves an ONNX inference, generates Groth16 calldata, verifies on-chain, and then executes USDC actions. Includes a simple Node UI and Python demo. See `docs/community-examples/agentkit-circle-ooak.md`.
+  - Repo: https://github.com/hshadab/agentkit/tree/main/Circle-OOAK
 
 Here is sample output from one run:
 

--- a/docs/community-examples/agentkit-circle-ooak.md
+++ b/docs/community-examples/agentkit-circle-ooak.md
@@ -1,0 +1,26 @@
+# OOAK × zkML (Community Example) — Trustless USDC Agents
+
+This community example composes OOAK secure tools with zkML proofs so an agent can gate sensitive actions (like USDC transfers) behind verifiable checks.
+
+- Example repo (by @hshadab): https://github.com/hshadab/agentkit/tree/main/Circle-OOAK
+- OOAK launch blog (by Mira Belenkiy): https://www.circle.com/blog/ooak-object-oriented-agent-kit
+
+## What It Shows
+- Map tool inputs to features, run real ONNX inference, and map results to an approval signal.
+- Generate Groth16 proofs for public signals (e.g., decision, confidence) and verify on-chain.
+- Optionally bind a JOLT proof hash for proof-of-execution in the audit record.
+- Execute a `@secure_tool` only after verifiable approval.
+
+## Quickstart
+Follow the README in the linked repo for setup and execution. At a high level:
+1) Clone the `agentkit` repo and navigate to `Circle-OOAK`.
+2) Provide environment variables (e.g., LLM/Chain) as instructed there.
+3) Install dependencies and run the Python demo and/or Node UI.
+
+## Notes
+- Community-maintained; this does not change OOAK’s API or runtime.
+- Issues with the example should be filed in the example repo.
+
+## Maintainer
+- Community example by @hshadab
+


### PR DESCRIPTION
- Summary
  - Adds a “Community Examples” section to README pointing to a community-maintained OOAK + zkML example that gates secure tools with verifiable checks (ONNX → Groth16 → on-chain verify) before executing USDC actions.
  - Adds a brief one‑pager under docs/community-examples with context and links.
- Motivation
  - Complements the OOAK launch by showcasing a trustless pattern for autonomous payments, while keeping this repo vendor‑neutral and lean.
- Changes
  - README: add “Community Examples”; fix “exmple” typo; fix GitHub example path.
  - New doc: docs/community-examples/agentkit-circle-ooak.md.
- How To Verify
  - Open README and follow the link; open the docs page for additional context.
  - Docs‑only; no API/runtime changes.
- Related Links
  - OOAK blog (Mira Belenkiy): https://www.circle.com/blog/ooak-object-oriented-agent-kit
  - Community example: https://github.com/hshadab/agentkit/tree/main/Circle-OOAK
- Checklist
  - [x] Docs-only change
  - [x] Follows README style
  - [x] No runtime changes
  - [x] Community attribution
