### PR TITLE
feat(v0.2.0): security upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,12 @@
 * **TECHOPS-18898:** use conventional commits and attach github release assets ([#9](https://github.com/circlefin/circle-ooak/issues/9)) ([dba08f5](https://github.com/circlefin/circle-ooak/commit/dba08f54b5661a31fead25c94637eb2caeb20644))
 * **TECHOPS-19100:** fix ci ([#10](https://github.com/circlefin/circle-ooak/issues/10)) ([552bde8](https://github.com/circlefin/circle-ooak/commit/552bde8416413efe214eb20562e55d70a3fbe1a9))
 * **TECHOPS-19100:** switch to public worfklow tokens ([#11](https://github.com/circlefin/circle-ooak/issues/11)) ([d0ac119](https://github.com/circlefin/circle-ooak/commit/d0ac119acd17584b1cac9c0f58e08c524be01385))
+
+## 0.2.0 (2026-06-30)
+This API breaking change closes a security vulnerability by adding intent verification during execution.
+
+* **API breaking change** Tools no longer need to take `wfid` as an argument.
+* **Security fix** Fixed vulnerability that allowed LLM to mix-and-match `wfid` and `intent`. This is now checked and enforced by OOAK framework.
+* **Tool failure support** The SecurityContext can supply an optional `on_invoke_tool_failure` hook that runs when a tool raises an exception.
+* **Added `bind_to_instance` on `InstanceAgent`** — optional runtime object id for instance identity to avoid name collisions across agents.
+

--- a/README.md
+++ b/README.md
@@ -19,19 +19,18 @@ to add before/after hooks to your tool code.
 a regular OpenAI Agents SDK `Agent` and can interact with other agents via handoffs and guardrails.
 
 
-This package includes a `WorkflowManager` that implements the abstract `SecurityContext`,
+This package includes a `WorkflowManager` that implements the abstract `SecureContext`,
 that checks that intended actions have been approved.
 
 1. Create intent. The agent calls the @secure_tool function with `wfid=None` argument. Instead of
 executing the function, it returns an intent: a json representation of the function call.
-2. Get Approval. The agent calls the WorkflowManager with a list of intents. The WorkflowManager
-approves the list of intents and returns a WorkflowId.
+2. Get Approval. The agent calls the WorkflowManager with a list of intents. The manager invokes `get_approval()` (which you override to connect your UX or policy) and, if approved, returns a WorkflowId.
 3. Execute. The agent now calls the @secure_tools in the correct order with the WorkflowId. The
 WorkflowManager ensures that each subsequent function call matches the approved workflow.
 
 Sample code can be found at `https://github.com/circlefin/circle-ooak/example`
 
-Below is an exmple of a `WalletWorkflowAgent`.
+Below is an example of a `WalletWorkflowAgent`.
 
 ```python
 from circle_ooak.instance_agent import InstanceAgent
@@ -68,7 +67,7 @@ class WalletWorkflowAgent(InstanceAgent):
             return f"Workflow not approved: {response.msg}"
 
     @secure_tool
-    def send_usdc(self, ctxt: RunContextWrapper[WorkflowManager], wfid: str, sender: str, receiver: str, amount: int):
+    def send_usdc(self, ctxt: RunContextWrapper[WorkflowManager], sender: str, receiver: str, amount: int):
         wallet = self.wallets[sender]
         if wallet is None:
             return f"Wallet {sender} not found"
@@ -86,6 +85,45 @@ agent = WalletWorkflowAgent(
     wallets=wallets
 )
 ```
+
+## Approval logic
+
+OOAK is a framework: it handles intent capture, workflow state, and **enforcement** (each `@secure_tool` call must match the approved plan). It does **not** include a production approval UI or policy engine.
+
+**You must connect your own UX and rules** by subclassing `WorkflowManager` and overriding `get_approval()`. The default implementation auto-approves every workflow so the demo runs without extra setup.
+
+Example:
+
+```python
+from circle_ooak.workflow_manager import WorkflowManager, ManagerResponse
+
+class MyWorkflowManager(WorkflowManager):
+    def __init__(self, approval_client, verbose: bool = False):
+        super().__init__(verbose=verbose)
+        self.approval_client = approval_client
+
+    def get_approval(self, workflow) -> ManagerResponse:
+        # Present workflow.actions to your UI or policy service.
+        # Each action.intent is JSON: function, arguments, and optional instance.
+        approved = self.approval_client.request_user_signoff(
+            wfid=workflow.wfid,
+            intents=[action.intent for action in workflow.actions],
+        )
+        if approved:
+            return ManagerResponse(True, "Approved")
+        return ManagerResponse(False, "User rejected workflow")
+```
+
+Pass your subclass as the runner context (as in `example/run_agent.py`):
+
+```python
+manager = MyWorkflowManager(approval_client=client, verbose=True)
+result = await Runner.run(agent, question, context=manager)
+```
+
+After approval, `WorkflowManager` ensures execution matches the stored intents (tool name, arguments, order) at **start** time. Your `get_approval()` implementation decides **whether** a workflow may run; the manager **enforces** your approvals.
+
+`approve()` validates intent shape (JSON structure and allowed keys). It does not require intents to come from a particular tool call — what matters is the **content** of each intent and whether your user or policy approves it in `get_approval()`.
 
 
 ## Setup Python environment
@@ -153,10 +191,10 @@ python -m pytest test/model_unit_test.py -v
 Here is sample output from one run:
 
 ```shell
-  Ask a question or type 'exit': Have 0x111111 mint 10 USDC to 0x222222 and then have 0x222222 send 5 USDC to 0x333333.
+Have 0x111111 mint 10 USDC to 0x222222 and then have 0x222222 send 5 USDC to 0x333333
 
 LOG: Approving workflow with intents: ['{"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}', '{"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"}']
-LOG: Approved workflow f0082344-018c-4d5c-856a-fb8989ab6bf2 with intents: [{"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}, {"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"}].
+LOG: Approved workflow e4aef3b4-2e32-47a4-a004-02b755dd62af with intents: [{"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}, {"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"}].
 Override this method with your own approval logic.
 
 LOG: Starting action {"function": "mint_usdc", "arguments": {"minter": "0x111111", "receiver": "0x222222", "amount": 10}, "instance": "Secure Agent"}
@@ -168,22 +206,58 @@ Sending 5 USDC from 0x222222 to 0x333333
 LOG: Finished action {"function": "send_usdc", "arguments": {"sender": "0x222222", "receiver": "0x333333", "amount": 5}, "instance": "Secure Agent"} with result txhash=1234567890
 
 LOG: Workflow completed successfully with result txhash=1234567890
-The transactions were successfully executed. Here are the transaction hashes:
+The transactions have been successfully executed:
 
-1. Mint 10 USDC from `0x111111` to `0x222222`: `txhash=0987654321`
-2. Send 5 USDC from `0x222222` to `0x333333`: `txhash=1234567890`
+1. Minting 10 USDC from 0x111111 to 0x222222 was successful with transaction hash: `0987654321`.
+2. Sending 5 USDC from 0x222222 to 0x333333 was successful with transaction hash: `1234567890`.
 
 ```
 
 ## Dev notes
-Functions decorated with `@secure_tool` must include the following two arguments:
-- `wfid: WorkflowId`. Agents will use the workflow id to get permission to perform tasks.
-- `ctxt: RunContextWrapper[SecurityContext]`. The runner must provide an object as context that
-implements the abstract class `SecurityContext` such as the `WorkflowManager` included in this project.
+Functions decorated with `@secure_tool` on an `InstanceAgent` should include `ctxt: RunContextWrapper[SecureContext]` when they need the workflow context. The runner must provide an object that implements `SecureContext` (for example `WorkflowManager`).
+
+OOAK uses a workflow id `wfid` to manage approvals. Do **not** include `wfid` in your Python function signature. Authorization metadata stays in the secure wrapper; your handler only receives arguments in the original function definition.
 
 
+For production use, subclass `WorkflowManager` and override `get_approval()`.
+You may also implement a custom `SecureContext` if you need different before/after hooks than the built-in workflow state machine.
+
+The included `WorkflowManager` is a **reference implementation** for demos and testing. It keeps approved workflows in memory for the life of the process. Production systems should subclass it for persistence, audit logs, branching logic, or other lifecycle needs.
+
+### Start, complete, and fail
+
+Each `@secure_tool` execution with a `wfid` uses three hooks:
+
+| Hook | Role |
+|------|------|
+| `before_invoke_tool` / `start()` | **Authorization** — verify the call matches the approved intent for the current step before the handler runs |
+| Handler | Your business logic |
+| `after_invoke_tool` / `complete()` | **Record success** — store the handler result and advance workflow state. Does not re-authorize; the handler already ran |
+| `on_invoke_tool_failure` / `fail()` | **Record failure** — best-effort transition to `failed` after a handler exception. Always succeeds; it must not leave the workflow stuck |
+
+### Instance identity in intents
+OOAK needs a way to uniquely identify agents for approval. There are two choices:
+- **by name**. When an `InstanceAgent` is initialized with `bind_to_instance=False`, then OOAK identifies the agent using the `name` supplied during object creation. This creates a stable name across restarts.
+- ** by object reference**. When an `InstanceAgent` is initialized with `bind_to_instance=True`, then OOAK identifies the agent
+using the run-time object identifier. This prevents any naming collisions. Agents have new ids after every restart. 
+
+### Side effects and workflow state
+
+OOAK calls `before_invoke_tool` (start) **before** your handler runs, and `after_invoke_tool` (complete) **after** it returns. If your handler performs an irreversible side effect (transfer funds, sign a transaction, call an external API) and then crashes or hangs, OOAK will not know the outcome of the action. It also will not know how to clean up.
+
+**What OOAK does:** the handler call is wrapped in a try/except. If the handler raises, `@secure_tool` calls `on_invoke_tool_failure`, which marks the current action and workflow as `failed`. This prevents a stuck `in_progress` state. It does **not** roll back side effects that already occurred before the exception.
+
+**What integrators should do:**
+
+- **Compensating tools** — write tools that perform their own cleanup on failure (refund, cancel reservation, revert a pending state). 
+- **Two-phase operations** — separate "prepare" and "commit" into different tools or workflow steps so approval covers each phase explicitly.
+- **Custom workflow logic** — subclass `WorkflowManager` or implement `SecureContext` with branching based on reported results (a decision tree), rather than assuming a fixed linear sequence, when your use case requires it.
+
+**Handler hangs and infinite loops:** OOAK does not enforce timeouts on tool handlers. A handler that never returns leaves the workflow step in `in_progress` indefinitely. Use `asyncio.wait_for`, application-level deadlines, or runner/SDK limits in your tool implementations and hosting environment.
+
+### Testing
 Agent tools with the `@secure_tool` or `@agent_tool` decorators can be tested the same way as those with `@function_tool`.
-We include a model unit test file.
+We include a model unit test file. Unit tests do not require an LLM.
 
 ```shell
 python -m pytest test/model_unit_test.py -v

--- a/example/wallet_agent.py
+++ b/example/wallet_agent.py
@@ -77,16 +77,14 @@ class WalletWorkflowAgent(InstanceAgent):
         super().__init__(name=name, instructions=self.instructions, model=model, tools=tools, agent_tools=agent_tools)
 
     @secure_tool
-    # all secure tools must have arguments RunContextWrapper[WorkflowManager] and wfid: str
-    def send_usdc(self, ctxt: RunContextWrapper[WorkflowManager], wfid: str, sender: str, receiver: str, amount: int):
+    def send_usdc(self, ctxt: RunContextWrapper[WorkflowManager], sender: str, receiver: str, amount: int):
         wallet = self.wallets[sender]
         if wallet is None:
             return f"Wallet {sender} not found"
         return wallet.send_usdc(receiver, amount)
 
     @secure_tool
-    # all secure tools must have arguments RunContextWrapper[WorkflowManager] and wfid: str
-    def mint_usdc(self, ctxt: RunContextWrapper[WorkflowManager], wfid: str, minter: str, receiver: str, amount: int):
+    def mint_usdc(self, ctxt: RunContextWrapper[WorkflowManager], minter: str, receiver: str, amount: int):
         wallet = self.wallets[minter]
         if wallet is None:
             return f"Wallet {minter} not found"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "circle-ooak"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name="Mira Belenkiy", email="mira.belenkiy@circle.com" },
 ]

--- a/src/circle_ooak/instance_agent.py
+++ b/src/circle_ooak/instance_agent.py
@@ -24,7 +24,16 @@ import copy
 from typing import Any
 
 class InstanceAgent(Agent):
-    def __init__(self, name: str, instructions: str, model: OpenAIChatCompletionsModel, tools: list[FunctionTool] = None, agent_tools: list[FunctionTool] = None):
+    def __init__(
+        self,
+        name: str,
+        instructions: str,
+        model: OpenAIChatCompletionsModel,
+        tools: list[FunctionTool] = None,
+        agent_tools: list[FunctionTool] = None,
+        bind_to_instance: bool = False,
+    ):
+        self.bind_to_instance = bind_to_instance
         # Handle None or empty cases
         if tools is None:
             tools = []

--- a/src/circle_ooak/secure_tool.py
+++ b/src/circle_ooak/secure_tool.py
@@ -16,6 +16,7 @@
 
 import json
 import inspect
+import copy
 from abc import ABC, abstractmethod
 from agents import (
     Agent,
@@ -31,6 +32,35 @@ from agents.util._error_tracing import attach_error_to_current_span
 from typing import Any, Callable, Union, ParamSpec, Concatenate
 
 from .agent_tool import agent_tool
+
+
+def get_instance_id(instance: Any) -> str:
+    if isinstance(instance, Agent) or hasattr(instance, "name"):
+        name = instance.name
+        if getattr(instance, "bind_to_instance", False):
+            return f"{name}_{id(instance)}"
+        return name
+    if hasattr(instance, "__str__"):
+        return str(instance)
+    return f"{instance.__class__.__name__}_{hex(id(instance))}"
+
+
+def strip_wfid_from_args(json_data: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in json_data.items() if k != "wfid"}
+
+
+def inject_wfid_into_schema(tool: FunctionTool) -> None:
+    schema = copy.deepcopy(tool.params_json_schema)
+    properties = schema.setdefault("properties", {})
+    properties["wfid"] = {
+        "anyOf": [{"type": "string"}, {"type": "null"}],
+        "description": "Workflow id from approval, or null to receive the intent JSON.",
+    }
+    required = list(schema.get("required", []))
+    if "wfid" not in required:
+        required.append("wfid")
+    schema["required"] = required
+    tool.params_json_schema = schema
 
 
 class SecureContextResponse: 
@@ -49,6 +79,10 @@ class SecureContext(ABC):
     @abstractmethod
     def after_invoke_tool(self, wfid: str, intent: str, result: str) -> SecureContextResponse:
         pass
+
+    def on_invoke_tool_failure(self, wfid: str, intent: str, error: str) -> SecureContextResponse:
+        """Called when a secure tool raises after before_invoke_tool succeeded."""
+        return SecureContextResponse(True, "Ignored")
 
 # required fields from agents:tools.py
 ToolParams = ParamSpec("ToolParams")
@@ -101,8 +135,9 @@ def secure_tool(
             description_override=description_override,
             docstring_style=docstring_style,
             use_docstring_info=use_docstring_info,
-            failure_error_function=failure_error_function,
+            failure_error_function=None,
         )
+        inject_wfid_into_schema(base_tool)
 
         # Append system_prompt to the tool's description
         if hasattr(base_tool, 'description') and base_tool.description:
@@ -114,8 +149,7 @@ def secure_tool(
         original_on_invoke = base_tool.on_invoke_tool
 
         def make_intent(json_data: dict[str, Any], instance: Any = None) -> str:
-            # Remove wfid from arguments for the intent since it's not part of the actual function
-            args_without_wfid = {k: v for k, v in json_data.items() if k != 'wfid'}
+            args_without_wfid = strip_wfid_from_args(json_data)
             formatted_data = {
                 "function": base_tool.name,
                 "arguments": args_without_wfid
@@ -124,15 +158,6 @@ def secure_tool(
                 formatted_data["instance"] = get_instance_id(instance)
             return json.dumps(formatted_data)
 
-        def get_instance_id(instance: Any) -> str:
-            if isinstance(instance, Agent) or hasattr(instance, 'name'):
-                return instance.name
-            elif hasattr(instance, '__str__'):
-                return str(instance)
-            else:
-                return f"{instance.__class__.__name__}_{hex(id(instance))}"
-
-
         async def before_invoke_tool(ctx: RunContextWrapper[Any], wfid: str, intent: str) -> dict[str, Any]:
             security_hooks: SecureContext = ctx.context
             return security_hooks.before_invoke_tool(wfid, intent)
@@ -140,6 +165,10 @@ def secure_tool(
         async def after_invoke_tool(ctx: RunContextWrapper[Any], wfid: str, intent: str, result: str) -> str:
             security_hooks: SecureContext = ctx.context
             return security_hooks.after_invoke_tool(wfid, intent, result)
+
+        async def fail_invoke_tool(ctx: RunContextWrapper[Any], wfid: str, intent: str, error: str) -> SecureContextResponse:
+            security_hooks: SecureContext = ctx.context
+            return security_hooks.on_invoke_tool_failure(wfid, intent, error)
 
         async def secure_on_invoke_tool(ctx: RunContextWrapper[Any], input: str, instance: Any = None) -> str:
             try:
@@ -160,15 +189,30 @@ def secure_tool(
                 if not status.approved:
                     return status.msg
 
-                # Call the original function with arguments excluding wfid
-                #args_without_wfid = {k: v for k, v in json_data.items() if k != 'wfid'}
-                #result = await original_on_invoke(ctx, json.dumps(args_without_wfid))
-                if instance is not None:
-                    result = await original_on_invoke(ctx, input, instance)
-                else:
-                    result = await original_on_invoke(ctx, input)
+                handler_input = json.dumps(strip_wfid_from_args(json_data))
+                try:
+                    if instance is not None:
+                        result = await original_on_invoke(ctx, handler_input, instance)
+                    else:
+                        result = await original_on_invoke(ctx, handler_input)
+                except Exception as e:
+                    await fail_invoke_tool(ctx, wfid, intent, str(e))
+                    if failure_error_function is None:
+                        raise
+                    result = failure_error_function(ctx, e)
+                    if inspect.isawaitable(result):
+                        result = await result
+                    attach_error_to_current_span(
+                        SpanError(
+                            message="Error running secure tool (non-fatal)",
+                            data={
+                                "tool_name": base_tool.name,
+                                "error": str(e),
+                            },
+                        )
+                    )
+                    return result
 
-                # Call security hooks after_invoke_tool
                 status = await after_invoke_tool(ctx, wfid, intent, result)
                 if not status.approved:
                     return status.msg
@@ -178,11 +222,11 @@ def secure_tool(
             except Exception as e:
                 if failure_error_function is None:
                     raise
-                
+
                 result = failure_error_function(ctx, e)
                 if inspect.isawaitable(result):
                     result = await result
-                
+
                 attach_error_to_current_span(
                     SpanError(
                         message="Error running secure tool (non-fatal)",

--- a/src/circle_ooak/workflow_manager.py
+++ b/src/circle_ooak/workflow_manager.py
@@ -25,6 +25,50 @@ class ManagerResponse(SecureContextResponse):
     def __init__(self, approved: bool, msg: str = None):
         super().__init__(approved, msg)
 
+
+
+
+_ALLOWED_INTENT_KEYS = frozenset({"function", "arguments", "instance"})
+
+
+def _validate_intent_data(intent: dict, label: str) -> ManagerResponse | None:
+    unknown = set(intent.keys()) - _ALLOWED_INTENT_KEYS
+    if unknown:
+        return ManagerResponse(
+            False,
+            f"{label} intent has unknown keys: {', '.join(sorted(unknown))}",
+        )
+    if "function" not in intent:
+        return ManagerResponse(False, f"{label} intent is missing required key: function")
+    if not isinstance(intent["function"], str) or not intent["function"]:
+        return ManagerResponse(False, f"{label} intent 'function' must be a non-empty string")
+    if "arguments" in intent and not isinstance(intent["arguments"], dict):
+        return ManagerResponse(False, f"{label} intent 'arguments' must be an object")
+    if "instance" in intent and not isinstance(intent["instance"], str):
+        return ManagerResponse(False, f"{label} intent 'instance' must be a string")
+    return None
+
+
+def _validate_intent_string(intent: str, label: str) -> ManagerResponse | None:
+    try:
+        data = json.loads(intent)
+    except json.JSONDecodeError:
+        return ManagerResponse(False, f"{label} intent is not valid JSON")
+    if not isinstance(data, dict):
+        return ManagerResponse(False, f"{label} intent must be a JSON object")
+    return _validate_intent_data(data, label)
+
+
+def _validate_intents(intents: list[str]) -> ManagerResponse | None:
+    if not intents:
+        return ManagerResponse(False, "Workflow must contain at least one intent")
+    for index, intent in enumerate(intents):
+        error = _validate_intent_string(intent, f"Intent {index + 1}")
+        if error is not None:
+            return error
+    return None
+
+
 class Action:
     enum = {
         'not_started': 'not_started',
@@ -45,43 +89,45 @@ class Action:
         return self.intent
 
     def has_matching_intent(self, intent: str) -> ManagerResponse:
-        # Compare JSON contents instead of string format to handle spacing differences
         try:
             current = json.loads(self.intent)
             incoming = json.loads(intent)
-            
-            # Compare function names
-            if current.get('function_name') != incoming.get('function_name') and current.get('function') != incoming.get('function'):
-                if self.intent != intent:
-                    return ManagerResponse(False, f"Function name mismatch: {current.get('function_name', current.get('function'))} vs {incoming.get('function_name', incoming.get('function'))}")
-
-            # Compare instance
-            if current.get('instance') != incoming.get('instance'):
-                if self.intent != intent:
-                    return ManagerResponse(False, f"Instance mismatch: {current.get('instance')} vs {incoming.get('instance')}")
-
-            # Compare arguments
-            current_args = {k: v for k, v in current.get('args', current.get('arguments', {})).items()}
-            incoming_args = {k: v for k, v in incoming.get('args', incoming.get('arguments', {})).items()}
-            
-            # Check if arguments match
-            if current_args != incoming_args:
-                if self.intent != intent:
-                    # Debugging output for mismatches
-                    for key in set(current_args.keys()) | set(incoming_args.keys()):
-                        if key not in current_args:
-                            return ManagerResponse(False, f"Missing argument in current intent: {key}")
-                        elif key not in incoming_args:
-                            return ManagerResponse(False, f"Missing argument in incoming intent: {key}")
-                        elif current_args[key] != incoming_args[key]:
-                            return ManagerResponse(False, f"Argument '{key}' mismatch: {current_args[key]} vs {incoming_args[key]}")
-            
-            # If we get here, the intents match
-            return ManagerResponse(True, 'Intents match')
-            
         except json.JSONDecodeError:
-             # Fall back to string comparison if JSON parsing fails
-            return ManagerResponse(self.intent == intent, 'Intents match')
+            approved = self.intent == intent
+            msg = "Intents match" if approved else "Intent string mismatch"
+            return ManagerResponse(approved, msg)
+
+        for label, data in (("Approved", current), ("Incoming", incoming)):
+            error = _validate_intent_data(data, label)
+            if error is not None:
+                return error
+
+        if current["function"] != incoming["function"]:
+            return ManagerResponse(
+                False,
+                f"Function name mismatch: {current['function']} vs {incoming['function']}",
+            )
+
+        if current.get("instance") != incoming.get("instance"):
+            return ManagerResponse(
+                False,
+                f"Instance mismatch: {current.get('instance')} vs {incoming.get('instance')}",
+            )
+
+        current_args = current.get("arguments", {})
+        incoming_args = incoming.get("arguments", {})
+        for key in set(current_args.keys()) | set(incoming_args.keys()):
+            if key not in current_args:
+                return ManagerResponse(False, f"Missing argument in approved intent: {key}")
+            if key not in incoming_args:
+                return ManagerResponse(False, f"Missing argument in incoming intent: {key}")
+            if current_args[key] != incoming_args[key]:
+                return ManagerResponse(
+                    False,
+                    f"Argument '{key}' mismatch: {current_args[key]} vs {incoming_args[key]}",
+                )
+
+        return ManagerResponse(True, "Intents match")
 
 class Workflow:
     enum = {
@@ -105,7 +151,6 @@ class Workflow:
         if self.verbose:
             print("LOG: " + message)
 
-    # todo: make thread safe
     def start(self, intent: str) -> ManagerResponse:
         with self._lock:  # Use lock to ensure thread safety
             # check if workflow is approved
@@ -118,8 +163,15 @@ class Workflow:
             
             # check if current action matches intent
             current_action = self.actions[self.current_action]
-            if not current_action.has_matching_intent(intent):
-                return ManagerResponse(False, 'Cannot start action, current action does not match intent: ' + current_action.intent + ' with status: ' + current_action.status)
+            match = current_action.has_matching_intent(intent)
+            if not match.approved:
+                return ManagerResponse(
+                    False,
+                    'Cannot start action, current action does not match intent: '
+                    + current_action.intent
+                    + '. '
+                    + match.msg,
+                )
             
             # check if current action is not started
             current_action = self.actions[self.current_action]
@@ -132,40 +184,59 @@ class Workflow:
             return ManagerResponse(True, 'Action started successfully')
 
     def complete(self, intent: str, result: any) -> ManagerResponse:
-        with self._lock:  # Use lock to ensure thread safety
-            # check if we've completed all actions
+        with self._lock:
+            # Records handler outcome. Authorization already happened in start().
             if self.current_action >= len(self.actions):
-                return ManagerResponse(False, 'All actions have been completed')
-                
-            # check if current action matches intent
+                self.log("complete called with no pending action")
+                return ManagerResponse(True, "No action to complete")
+
             current_action = self.actions[self.current_action]
-            if not current_action.has_matching_intent(intent):
-                return ManagerResponse(False, 'Cannot complete action, current action does not match intent: ' + current_action.intent + ' with status: ' + current_action.status)
-            
-            # check if action is in progress
-            if current_action.status != Action.enum['in_progress']:
-                return ManagerResponse(False, 'Cannot complete action, current action is not in progress: ' + current_action.intent + ' with status: ' + current_action.status)
-            
-            # update result and status
-            current_action.result = result
-            current_action.status = Action.enum['completed']
-            
-            # Move to next action
-            self.current_action += 1
-            
-            # If we've completed all actions, update workflow status
-            if self.current_action >= len(self.actions):
-                self.status = Workflow.enum['completed']
-                self.result = result
-                self.log(f"Finished action {current_action.intent} with result {result}")
-                self.log(f"Workflow completed successfully with result {result}")
-                return ManagerResponse(True, 'Workflow completed successfully')
-            else:
-                # Reset the next action's status to not_started if it exists
+            if current_action.status == Action.enum['in_progress']:
+                current_action.result = result
+                current_action.status = Action.enum['completed']
+                self.current_action += 1
+
+                if self.current_action >= len(self.actions):
+                    self.status = Workflow.enum['completed']
+                    self.result = result
+                    self.log(f"Finished action {current_action.intent} with result {result}")
+                    self.log(f"Workflow completed successfully with result {result}")
+                    return ManagerResponse(True, "Workflow completed successfully")
+
                 next_action = self.actions[self.current_action]
                 next_action.status = Action.enum['not_started']
                 self.log(f"Finished action {current_action.intent} with result {result}")
-                return ManagerResponse(True, 'Action completed successfully, ready for next action')
+                return ManagerResponse(True, "Action completed successfully, ready for next action")
+
+            self.log(
+                "complete called for action not in progress: "
+                + current_action.intent
+                + " with status: "
+                + current_action.status
+            )
+            return ManagerResponse(True, "Action already finalized")
+
+    def fail(self, intent: str, error: str) -> ManagerResponse:
+        with self._lock:
+            # Best-effort failure recording. Must not raise or reject after handler errors.
+            if self.current_action < len(self.actions):
+                current_action = self.actions[self.current_action]
+                if current_action.status == Action.enum['in_progress']:
+                    current_action.result = error
+                    current_action.status = Action.enum['failed']
+                    self.status = Workflow.enum['failed']
+                    self.result = error
+                    self.log(f"Failed action {current_action.intent} with error {error}")
+                else:
+                    self.log(
+                        "fail called for action not in progress: "
+                        + current_action.intent
+                        + " with status: "
+                        + current_action.status
+                    )
+            else:
+                self.log("fail called with no pending action")
+            return ManagerResponse(True, "Action failed")
 
 class WorkflowManager(SecureContext):
     def __init__(self, verbose: bool = False, managed_context: dict[str, any] = None):
@@ -185,6 +256,10 @@ class WorkflowManager(SecureContext):
     # AI agents can call this function to get approval for a workflow
     def approve(self, intents: list[str]) -> ManagerResponse:
         self.log(f"Approving workflow with intents: {intents}")
+        validation = _validate_intents(intents)
+        if validation is not None:
+            return validation
+
         # generate workflow and wfid
         workflow = Workflow(intents, self.verbose)
         wfid = workflow.wfid
@@ -215,12 +290,22 @@ class WorkflowManager(SecureContext):
         workflow = self.workflows[wfid]
         return workflow.complete(intent, result)
 
+    def fail(self, wfid: str, intent: str, error: str) -> ManagerResponse:
+        if wfid not in self.workflows:
+            return ManagerResponse(False, 'Workflow not found')
+
+        workflow = self.workflows[wfid]
+        return workflow.fail(intent, error)
+
     # Implementation of SecureContext interface
     def before_invoke_tool(self, wfid: str, intent: str) -> ManagerResponse:
         return self.start(wfid, intent)
     
     def after_invoke_tool(self, wfid: str, intent: str, result: str) -> ManagerResponse:
         return self.complete(wfid, intent, result)
+
+    def on_invoke_tool_failure(self, wfid: str, intent: str, error: str) -> ManagerResponse:
+        return self.fail(wfid, intent, error)
 
 
 

--- a/test/model_unit_test.py
+++ b/test/model_unit_test.py
@@ -18,21 +18,24 @@ import json
 import unittest
 
 from agents import RunContextWrapper
-from circle_ooak.workflow_manager import WorkflowManager
+from circle_ooak.workflow_manager import WorkflowManager, Action, Workflow
 from circle_ooak.instance_agent import InstanceAgent
-from circle_ooak.secure_tool import secure_tool
-from circle_ooak.agent_tool import agent_tool
+from circle_ooak.secure_tool import secure_tool, agent_tool, get_instance_id
 
 # define two static functions that are secure tools that we want to test
 @secure_tool
-def send_usdc(wfid: str, sender: str, receiver: str, amount: int):
+def send_usdc(sender: str, receiver: str, amount: int):
     print(f"Sending {amount} USDC from {sender} to {receiver}")
     return "txhash=1234567890"
 
 @secure_tool
-def mint_usdc(wfid: str, minter: str, receiver: str, amount: int):
+def mint_usdc(minter: str, receiver: str, amount: int):
     print(f"Minting {amount} USDC by {minter} to {receiver}")
     return "txhash=1234567890"
+
+@secure_tool
+def failing_mint(minter: str, receiver: str, amount: int):
+    raise RuntimeError("mint failed")
 
 # define a class that has a method that is an agent tool
 class Wallet:
@@ -54,7 +57,7 @@ class PermissionedWallet:
         self.address = address
     
     @secure_tool
-    def mint_usdc(self, wfid: str, receiver: str, amount: int):
+    def mint_usdc(self, receiver: str, amount: int):
         print(f"Sending {amount} USDC from {self.address} to {receiver}")
         return "txhash=1234567890"
 
@@ -160,6 +163,115 @@ class TestWorkflowAndTools(unittest.IsolatedAsyncioTestCase):
         #make sure tool_a is still attached to wallet_a
         address_a = await tool_a.on_invoke_tool(context, json.dumps(input_data))
         self.assertEqual(address_a, wallet_a.address) # this should succeed
+
+    def test_get_instance_id_bind_to_instance(self):
+        class NamedStub:
+            def __init__(self, name: str, bind_to_instance: bool = False):
+                self.name = name
+                self.bind_to_instance = bind_to_instance
+
+        by_name = NamedStub("Secure Agent", bind_to_instance=False)
+        self.assertEqual(get_instance_id(by_name), "Secure Agent")
+
+        by_object = NamedStub("Secure Agent", bind_to_instance=True)
+        self.assertEqual(get_instance_id(by_object), f"Secure Agent_{id(by_object)}")
+
+
+class TestWorkflowSecurity(unittest.IsolatedAsyncioTestCase):
+    """Regression tests for workflow intent enforcement."""
+
+    def test_rejects_altered_arguments_after_approval(self):
+        approved = json.dumps(
+            {
+                "function": "send_usdc",
+                "arguments": {"sender": "0xA", "receiver": "0xB", "amount": 1},
+                "instance": "Secure Agent",
+            }
+        )
+        altered = json.dumps(
+            {
+                "function": "send_usdc",
+                "arguments": {"sender": "0xA", "receiver": "0xC", "amount": 999},
+                "instance": "Secure Agent",
+            }
+        )
+
+        action = Action(approved)
+        match = action.has_matching_intent(altered)
+        self.assertFalse(match.approved)
+        self.assertIn("mismatch", match.msg)
+
+        manager = WorkflowManager()
+        wfid = manager.approve([approved]).msg
+        start = manager.start(wfid, altered)
+        self.assertFalse(start.approved)
+
+    def test_rejects_different_tool_with_same_arguments(self):
+        approved = json.dumps(
+            {
+                "function": "approved_transfer",
+                "arguments": {"receiver": "0xB", "amount": 1},
+            }
+        )
+        dangerous = json.dumps(
+            {
+                "function": "dangerous_transfer",
+                "arguments": {"receiver": "0xB", "amount": 1},
+            }
+        )
+
+        action = Action(approved)
+        match = action.has_matching_intent(dangerous)
+        self.assertFalse(match.approved)
+        self.assertIn("Function name mismatch", match.msg)
+
+        manager = WorkflowManager()
+        wfid = manager.approve([approved]).msg
+        start = manager.start(wfid, dangerous)
+        self.assertFalse(start.approved)
+
+    def test_approve_rejects_invalid_intent_shape(self):
+        manager = WorkflowManager()
+
+        empty = manager.approve([])
+        self.assertFalse(empty.approved)
+        self.assertIn("at least one intent", empty.msg)
+
+        bad_json = manager.approve(["not json"])
+        self.assertFalse(bad_json.approved)
+        self.assertIn("not valid JSON", bad_json.msg)
+
+        missing_function = manager.approve([json.dumps({"arguments": {}})])
+        self.assertFalse(missing_function.approved)
+        self.assertIn("function", missing_function.msg)
+
+        unknown_key = manager.approve(
+            [json.dumps({"function": "send_usdc", "arguments": {}, "wfid": "x"})]
+        )
+        self.assertFalse(unknown_key.approved)
+        self.assertIn("unknown keys", unknown_key.msg)
+
+    async def test_tool_exception_marks_action_failed(self):
+        manager = WorkflowManager(verbose=True)
+        context = RunContextWrapper(manager)
+
+        input_data = {"wfid": None, "minter": "0x1", "receiver": "0x2", "amount": 1}
+        intent = await failing_mint.on_invoke_tool(context, json.dumps(input_data))
+        wfid = manager.approve([intent]).msg
+        workflow = manager.workflows[wfid]
+
+        execute_data = {"wfid": wfid, "minter": "0x1", "receiver": "0x2", "amount": 1}
+        output = await failing_mint.on_invoke_tool(context, json.dumps(execute_data))
+        self.assertIsNotNone(output)
+
+        action = workflow.actions[0]
+        self.assertEqual(action.status, Action.enum["failed"])
+        self.assertEqual(action.result, "mint failed")
+        self.assertEqual(workflow.status, Workflow.enum["failed"])
+
+        retry = manager.start(wfid, intent)
+        self.assertFalse(retry.approved)
+        self.assertIn("failed", retry.msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This API breaking change closes a security vulnerability by adding intent verification during execution.

* **API breaking change** Tools no longer need to take `wfid` as an argument.
* **Security fix** Fixed vulnerability that allowed LLM to mix-and-match `wfid` and `intent`. This is now checked and enforced by OOAK framework.
* **Tool failure support** The SecurityContext can supply an optional `on_invoke_tool_failure` hook that runs when a tool raises an exception.
* **Added `bind_to_instance` on `InstanceAgent`** — optional runtime object id for instance identity to avoid name collisions across agents.